### PR TITLE
goreleaser v2に対応

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -1,7 +1,7 @@
 name: Daily Integration Test
 on:
   schedule:
-    - cron: '30 23 * * *'
+    - cron: "30 23 * * *"
   workflow_dispatch:
 env:
   GOPROXY: https://proxy.golang.org
@@ -22,10 +22,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: "go.mod"
 
       - name: Setup tools
-        run: | 
+        run: |
           make tools
 
       - name: make test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    tags: 'v[0-9]+.[0-9]+.[0-9]+'
+    tags: "v[0-9]+.[0-9]+.[0-9]+"
 
 env:
   GOPROXY: https://proxy.golang.org
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: "go.mod"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,14 +16,14 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: "go.mod"
 
       - name: Setup tools
         run: |
           make tools
 
       - name: make lint-text
-        run:  |
+        run: |
           make lint-text
   lint-go:
     name: lint-go
@@ -38,14 +38,14 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: "go.mod"
 
       - name: Setup tools
-        run: | 
+        run: |
           make tools
 
       - name: make lint-go
-        run:  |
+        run: |
           # Explicitly set GOROOT to avoid golangci-lint/issues/3107
           GOROOT=$(go env GOROOT)
           export GOROOT
@@ -64,10 +64,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: "go.mod"
 
       - name: Setup tools
-        run: | 
+        run: |
           make tools
 
       - name: make test

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,7 @@
-build:
-  skip: true
+version: 2
+builds:
+  - skip: true
 release:
   draft: false
 changelog:
-  skip: false
+  disable: false


### PR DESCRIPTION
## 背景
https://github.com/sacloud/packages-go/pull/64 によりgoreleaser v2が使われるようになったため関連する設定項目を修正する

https://github.com/sacloud/webaccel-api-go/pull/56 を参考にしています。

## 変更点
- goreleaserのconfigをv2に対応
- GitHub ActionsでGoのバージョン判定にgo.modを利用するように変更