### PR TITLE
copyright 2025

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,11 @@ run:
 issues:
   max-per-linter: 0
   max-same-issues: 0
+  exclude-rules:
+    - linters:
+        - gosec
+      text: "integer overflow conversion"
+      path: cidr/
 
 linters:
   disable-all: true

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2022-2023 The sacloud/packages-go Authors
+# Copyright 2022-2025 The sacloud/packages-go Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 #====================
 AUTHOR         ?= The sacloud/packages-go Authors
-COPYRIGHT_YEAR ?= 2022-2023
+COPYRIGHT_YEAR ?= 2022-2025
 
 include includes/go/common.mk
 #====================

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@
 
 ## License
 
-`sacloud/packages-go` Copyright (C) 2022-2023 [The sacloud/packages-go Authors](AUTHORS).
+`sacloud/packages-go` Copyright (C) 2022-2025 [The sacloud/packages-go Authors](AUTHORS).
 
 This project is published under [Apache 2.0 License](LICENSE.txt).

--- a/cidr/cidr.go
+++ b/cidr/cidr.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/e2e/commands.go
+++ b/e2e/commands.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/e2e/output.go
+++ b/e2e/output.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/e2e/request.go
+++ b/e2e/request.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/e2e/terraform.go
+++ b/e2e/terraform.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/envvar/envvar.go
+++ b/envvar/envvar.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mutexkv/mutexkv.go
+++ b/mutexkv/mutexkv.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/newsfeed/functions.go
+++ b/newsfeed/functions.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/newsfeed/functions_test.go
+++ b/newsfeed/functions_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/newsfeed/newsfeed.go
+++ b/newsfeed/newsfeed.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/objutil/empty.go
+++ b/objutil/empty.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/objutil/slice.go
+++ b/objutil/slice.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/objutil/slice_test.go
+++ b/objutil/slice_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pointer/primitive.go
+++ b/pointer/primitive.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pointer/slice.go
+++ b/pointer/slice.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/size/size.go
+++ b/size/size.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/size/size_test.go
+++ b/size/size_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/wait/polling.go
+++ b/wait/polling.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/wait/waiter.go
+++ b/wait/waiter.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/wait/waiter_test.go
+++ b/wait/waiter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The sacloud/packages-go Authors
+// Copyright 2022-2025 The sacloud/packages-go Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Note: cidr/cidr.goでlintエラーが出ていたが、アップストリームに追随していく部分のためソースの修正ではなくルールの変更で対応した。