### PR TITLE
chore: add CHANGELOG* to .textlintignore

### DIFF
--- a/.textlintignore
+++ b/.textlintignore
@@ -1,2 +1,3 @@
 LICENSE
 dist/
+CHANGELOG*


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

textlintがエラーになる問題への対応
tagprが生成するCHANGELOG.mdを無視するようにします

### ドキュメントの変更は必要ですか？

no